### PR TITLE
fix: stop Wave Player retry storm

### DIFF
--- a/hooks/wave-player/use-wave-player.ts
+++ b/hooks/wave-player/use-wave-player.ts
@@ -4,18 +4,21 @@ import { useEffect, useState } from "react";
 import { useWavePlayerContext } from "@/contexts/wave-player-context";
 
 export function useWavePlayer() {
-  const { state, controls, initialize, loadTrack, retryLoad } = useWavePlayerContext();
+  const { state, controls, initialize, loadTrack, retryLoad } =
+    useWavePlayerContext();
   const [hasInitialized, setHasInitialized] = useState(false);
 
   // Initialize the audio context once
   useEffect(() => {
     if (!hasInitialized && state.status === "idle") {
       console.log("[useWavePlayer] initializing audio context");
-      initialize().then(() => {
-        setHasInitialized(true);
-      }).catch(error => {
-        console.error("[useWavePlayer] Error initializing:", error);
-      });
+      initialize()
+        .then(() => {
+          setHasInitialized(true);
+        })
+        .catch((error) => {
+          console.error("[useWavePlayer] Error initializing:", error);
+        });
     }
   }, [initialize, state.status, hasInitialized]);
 
@@ -24,12 +27,18 @@ export function useWavePlayer() {
     const playlist = state.playlist;
     if (!playlist || playlist.tracks.length === 0 || !hasInitialized) return;
 
-    // Only load track if we're not already loading or playing
-    if (state.status === "idle" || state.status === "error") {
+    // Failed loads wait for the user to trigger retryLoad explicitly.
+    if (state.status === "idle") {
       console.log("[useWavePlayer] Loading initial track");
       loadTrack(playlist.tracks[state.currentTrackIndex]);
     }
-  }, [state.playlist, state.currentTrackIndex, state.status, loadTrack, hasInitialized]);
+  }, [
+    state.playlist,
+    state.currentTrackIndex,
+    state.status,
+    loadTrack,
+    hasInitialized,
+  ]);
 
   return {
     state,
@@ -39,5 +48,3 @@ export function useWavePlayer() {
     retryLoad,
   };
 }
-
-

--- a/tests/wave-player.test.tsx
+++ b/tests/wave-player.test.tsx
@@ -451,6 +451,28 @@ describe("WavePlayer System", () => {
       });
     });
 
+    it("should wait for an explicit retry after the initial track fails", async () => {
+      mockLoadTrackChunked.mockReset();
+      mockLoadTrackChunked
+        .mockRejectedValueOnce(new Error("Failed to load track"))
+        .mockImplementationOnce(() => new Promise(() => undefined));
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WavePlayerProvider playlist={mockPlaylist}>
+          {children}
+        </WavePlayerProvider>
+      );
+
+      const { result } = renderHook(() => useWavePlayer(), { wrapper });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(mockLoadTrackChunked).toHaveBeenCalledTimes(1);
+      expect(result.current.state.status).toBe("error");
+    });
+
     it("should handle retry loading", async () => {
       // Set up mock to fail and then succeed
       mockLoadTrackChunked.mockReset();


### PR DESCRIPTION
## Summary

- stop the initial-track effect from immediately retrying after a load failure
- keep failed loads in the error state until the existing explicit Retry action is used
- add a hook-level regression covering the production request storm

## Root cause

Production audio requests fail on the canonical `https://www.kalynbeach.net` origin because the S3 bucket CORS rule currently allows `https://kalynbeach.net` but not `https://www.kalynbeach.net`. The hook then treated `error` like `idle`, causing each failure to trigger another load and repeated S3 HEAD requests.

## Hosted configuration

- Vercel cleanup completed: removed confirmed-unused Supabase, Postgres, and Auth.js variables; retained Clerk, Convex, and `NEXT_PUBLIC_SITE_URL`
- S3 CORS update pending: the available local AWS profile is `amplify-kalyn` and lacks `s3:GetBucketCORS`, so the exact `www` origin must be added through an authorized AWS session before production audio verification

## Checks

- `bunx vitest run tests/wave-player.test.tsx` — 18 passed
- `bunx vitest run` — 60 passed
- `bunx tsc --noEmit --incremental false` — passed
- targeted ESLint — passed
- targeted Prettier — passed
- `bun run build` — passed (Next.js 16.2.10, 15 routes)
- `git diff --check` — passed
- `bun run lint` — unchanged legacy baseline: 17 errors and 22 warnings, all outside the two changed files